### PR TITLE
Fix that having a unicode character incorrect would immediately panic

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -90,7 +90,11 @@ impl Widget for &Test {
                 }))
                 .chain(iter::once(vec![
                     Span::styled(
-                        self.words[self.current_word].text.chars().take(progress_ind).collect::<String>(),
+                        self.words[self.current_word]
+                            .text
+                            .chars()
+                            .take(progress_ind)
+                            .collect::<String>(),
                         Style::default()
                             .fg(
                                 match self.words[self.current_word]
@@ -104,7 +108,12 @@ impl Widget for &Test {
                             .add_modifier(Modifier::BOLD),
                     ),
                     Span::styled(
-                        self.words[self.current_word].text.chars().skip(progress_ind).collect::<String>() + " ",
+                        self.words[self.current_word]
+                            .text
+                            .chars()
+                            .skip(progress_ind)
+                            .collect::<String>()
+                            + " ",
                         Style::default()
                             .fg(Color::Yellow)
                             .add_modifier(Modifier::BOLD),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -90,7 +90,7 @@ impl Widget for &Test {
                 }))
                 .chain(iter::once(vec![
                     Span::styled(
-                        self.words[self.current_word].text[..progress_ind].to_string(),
+                        self.words[self.current_word].text.chars().take(progress_ind).collect::<String>(),
                         Style::default()
                             .fg(
                                 match self.words[self.current_word]
@@ -104,7 +104,7 @@ impl Widget for &Test {
                             .add_modifier(Modifier::BOLD),
                     ),
                     Span::styled(
-                        self.words[self.current_word].text[progress_ind..].to_string() + " ",
+                        self.words[self.current_word].text.chars().skip(progress_ind).collect::<String>() + " ",
                         Style::default()
                             .fg(Color::Yellow)
                             .add_modifier(Modifier::BOLD),


### PR DESCRIPTION
Previously, having a multi-byte UTF-8 character incorrect would immediately panic due to byte-indexing in the middle of the character. This pull request changes the two places that use this to use the chars iterator instead.