### PR TITLE
fix: Reworked how WPM is calculated

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -196,13 +196,18 @@ impl Widget for &results::Results {
         info_text.extend(vec![
             Spans::from(format!(
                 "Adjusted WPM: {:.1}",
-                self.cps.overall * 12f64 * f64::from(self.accuracy.overall)
+                (self.cps.overall / self.average_word_length)
+                    * 60f64
+                    * f64::from(self.accuracy.overall)
             )),
             Spans::from(format!(
                 "Accuracy: {:.1}%",
                 f64::from(self.accuracy.overall) * 100f64
             )),
-            Spans::from(format!("Raw WPM: {:.1}", self.cps.overall * 12f64)),
+            Spans::from(format!(
+                "Raw WPM: {:.1}",
+                (self.cps.overall / self.average_word_length) * 60f64
+            )),
             Spans::from(format!("Correct Keypresses: {}", self.accuracy.overall)),
         ]);
 


### PR DESCRIPTION
Closes #22 

WPM calculations are now much more comparable to other popular typing test websites. This was accomplished through the following fixes and changes:
- Instead of using a constant size of `5` for the average word length of any typing test, we instead compute `average_word_length` as a `f64` field inside of the `Results` struct
- Fixing how CPS is calculated, as there were a few miscalculations and typos that would make the WPM much larger than it should have been.