### PR TITLE
an easy way to restart without refactoring the entire codebase

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -113,7 +113,11 @@ impl Opt {
     }
 }
 
-fn run_test(mut test: Test) -> crossterm::Result<bool> {
+fn run_test(mut test: Test) -> crossterm::Result<i8> {
+    // 0 for test done
+    // 1 for restart
+    // -1 for quit
+
     let mut stdout = io::stdout();
 
     execute!(
@@ -139,14 +143,14 @@ fn run_test(mut test: Test) -> crossterm::Result<bool> {
             Event::Key(key) => {
                 if key.modifiers.contains(KeyModifiers::CONTROL) {
                     if let KeyCode::Char('c') = key.code {
-                        return Ok(false);
+                        return Ok(-1);
                     };
                 }
 
                 match key.code {
                     KeyCode::Esc => break,
                     KeyCode::Tab => {
-                        return Ok(true);
+                        return Ok(1);
                     },
                     _ => test.handle_key(key),
                 }
@@ -174,7 +178,7 @@ fn run_test(mut test: Test) -> crossterm::Result<bool> {
     terminal.draw(|f| {
         f.render_widget(&results, f.size());
     })?;
-    Ok(true)
+    Ok(0)
 }
 
 fn exit() -> crossterm::Result<()> {
@@ -208,17 +212,31 @@ fn main() -> crossterm::Result<()> {
             return Ok(());
         };
 
-        if run_test(Test::new(contents))? {
-            match event::read()? {
-                Event::Key(KeyEvent {
-                    code: KeyCode::Tab,
-                    modifiers: KeyModifiers::NONE,
-                }) => (),
+        // if run_test(Test::new(contents))? {
+        //     match event::read()? {
+        //         Event::Key(KeyEvent {
+        //             code: KeyCode::Tab,
+        //             modifiers: KeyModifiers::NONE,
+        //         }) => (),
 
-                _ => break,
-            }
-        } else {
-            return exit();
+        //         _ => break,
+        //     }
+        // } else {
+        //     return exit();
+        // }
+        match run_test(Test::new(contents))? {
+            0 => {
+                match event::read()? {
+                    Event::Key(KeyEvent {
+                        code: KeyCode::Tab,
+                        modifiers: KeyModifiers::NONE,
+                    }) => (),
+                    _ => break,
+                }
+            },
+            1 => {continue},
+            -1 => break,
+            _ => break,
         }
     }
     exit()

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,6 +115,7 @@ impl Opt {
 
 fn run_test(mut test: Test) -> crossterm::Result<bool> {
     let mut stdout = io::stdout();
+
     execute!(
         stdout,
         cursor::Hide,
@@ -144,6 +145,9 @@ fn run_test(mut test: Test) -> crossterm::Result<bool> {
 
                 match key.code {
                     KeyCode::Esc => break,
+                    KeyCode::Tab => {
+                        return Ok(true);
+                    },
                     _ => test.handle_key(key),
                 }
 
@@ -207,9 +211,10 @@ fn main() -> crossterm::Result<()> {
         if run_test(Test::new(contents))? {
             match event::read()? {
                 Event::Key(KeyEvent {
-                    code: KeyCode::Char('r'),
+                    code: KeyCode::Tab,
                     modifiers: KeyModifiers::NONE,
                 }) => (),
+
                 _ => break,
             }
         } else {

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -109,6 +109,10 @@ impl Test {
                     correct: Some(word.text.starts_with(&word.progress[..])),
                     key,
                 });
+                if word.progress == word.text && self.current_word == self.words.len() - 1 {
+                    self.complete = true;
+                    self.current_word = 0;
+                }
             }
             _ => {}
         };

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -186,7 +186,7 @@ impl Widget for &results::Results {
             .split(chunks[0]);
 
         let exit = Span::styled(
-            "Press any key to finish or 'r' for a another test.",
+            "Press any key to finish or TAB for a another test.",
             Style::default()
                 .fg(Color::Gray)
                 .add_modifier(Modifier::ITALIC),


### PR DESCRIPTION
Pressing Tab twice to restart (with new contents too). If you press something when you press Tab for the first time, it will exit.

It's not a bug, it's a feature.