### PR TITLE
Make it colorblind friendly

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -125,7 +125,7 @@ impl Widget for &Test {
                             .collect::<String>()
                             + " ",
                         Style::default()
-                            .fg(Color::Yellow)
+                            .fg(Color::Blue)
                             .add_modifier(Modifier::BOLD),
                     ),
                 ]))
@@ -306,7 +306,10 @@ impl Widget for &results::Results {
             )
             .y_axis(
                 Axis::default()
-                    .title(Span::styled("WPM (10-keypress rolling average)", Style::default().fg(Color::Gray)))
+                    .title(Span::styled(
+                        "WPM (10-keypress rolling average)",
+                        Style::default().fg(Color::Gray),
+                    ))
                     .bounds([wpm_sma_min, wpm_sma_max])
                     .labels(
                         (wpm_sma_min as u16..wpm_sma_max as u16)


### PR DESCRIPTION
I really like `ttyper`
The simplicity, straightforwardness, pure typing and stats at the end! Love it!

But I have severe problems when there is a typo midway through the word. As a colorblind person, I cannot easily distinguish scales of red so well, so when the word is half yellow half green, it is very hard to distinguish where the cursor is (or even realize if a word is fully "OK" or the last character is yellow). To understand the cases that I mean, maybe you can try setting your colors to green **OK** and green **ONGOING**, it gets really tricky at the end of words especially!!
Well, since I'm probably not alone here, and about 10% of the male population might have the same feeling, I'm creating this PR.

Basically, a word will never be half green half yellow. Either fully green, half green and half blue (far enough), or fully red.
But you might ask "full green or full red? isn't that a problem?". Well, generally yes. But red looks a look darker than green in full blown RGB (`#ff0000` vs `#00ff00`). I think it has to do with humans having a lot more receptors for green than any other color ¯\\_(ツ)_/¯, but I'm no doctor. I just know what I see 😄 

I thought this PR was simple enough, unintrusive enough, and doesn't really break the simple straightforward feel. (BTW, the extra line change was just an automatic `cargo fmt`)
I hope this is ok with you