### PR TITLE
Mark individual incorrect characters

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -341,12 +341,3 @@ impl ThemedWidget for &results::Results {
         wpm_chart.render(res_chunks[1], buf);
     }
 }
-
-// FIXME: replace with `str::ceil_char_boundary` when stable
-fn ceil_char_boundary(string: &str, index: usize) -> usize {
-    if string.is_char_boundary(index) {
-        index
-    } else {
-        ceil_char_boundary(string, index + 1)
-    }
-}


### PR DESCRIPTION
As suggested in #75, when mistype happens, only mark ~~the wrong characters~~ starting from the first wrong character to the end, instead of the entire word.

A byproduct of marking individual characters is that it also fixes some issues mentioned in #77 (for example, accented letters like ä or é being counted as two characters).

Likely will conflict with #90. I'm submitting a PR since someone has requested it. Feel free to close if there are better solutions (or maybe use this as a temporary fix for v1, as the code change is not significant) .