### PR TITLE
Increase WPM y-label range to at least 5

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -291,47 +291,49 @@ impl ThemedWidget for &results::Results {
             })
             .collect();
 
-        let wpm_sma_min = wpm_sma
-            .iter()
-            .map(|(_, x)| x)
-            .fold(f64::INFINITY, |a, &b| a.min(b));
-        let wpm_sma_max = wpm_sma
-            .iter()
-            .map(|(_, x)| x)
-            .fold(f64::NEG_INFINITY, |a, &b| a.max(b));
+        if !wpm_sma.is_empty() { // In case there's a chart to render
+            let wpm_sma_min = wpm_sma
+                .iter()
+                .map(|(_, x)| x)
+                .fold(f64::INFINITY, |a, &b| a.min(b));
+            let wpm_sma_max = wpm_sma
+                .iter()
+                .map(|(_, x)| x)
+                .fold(f64::NEG_INFINITY, |a, &b| a.max(b));
 
-        let wpm_datasets = vec![Dataset::default()
-            .name("WPM")
-            .marker(Marker::Braille)
-            .graph_type(GraphType::Line)
-            .style(theme.results_chart)
-            .data(&wpm_sma)];
+            let wpm_datasets = vec![Dataset::default()
+                .name("WPM")
+                .marker(Marker::Braille)
+                .graph_type(GraphType::Line)
+                .style(theme.results_chart)
+                .data(&wpm_sma)];
 
-        let y_label_min = wpm_sma_min as u16;
-        let y_label_max = (wpm_sma_max as u16).max(y_label_min + 6);
+            let y_label_min = wpm_sma_min as u16;
+            let y_label_max = (wpm_sma_max as u16).max(y_label_min + 6);
 
-        let wpm_chart = Chart::new(wpm_datasets)
-            .block(Block::default().title(vec![Span::styled("Chart", theme.title)]))
-            .x_axis(
-                Axis::default()
-                    .title(Span::styled("Keypresses", theme.results_chart_x))
-                    .bounds([0.0, self.timing.per_event.len() as f64]),
-            )
-            .y_axis(
-                Axis::default()
-                    .title(Span::styled(
-                        "WPM (10-keypress rolling average)",
-                        theme.results_chart_y,
-                    ))
-                    .bounds([wpm_sma_min, wpm_sma_max])
-                    .labels(
-                        (y_label_min..y_label_max)
-                            .step_by(5)
-                            .map(|n| Span::raw(format!("{}", n)))
-                            .collect(),
-                    ),
-            );
-        wpm_chart.render(res_chunks[1], buf);
+            let wpm_chart = Chart::new(wpm_datasets)
+                .block(Block::default().title(vec![Span::styled("Chart", theme.title)]))
+                .x_axis(
+                    Axis::default()
+                        .title(Span::styled("Keypresses", theme.results_chart_x))
+                        .bounds([0.0, self.timing.per_event.len() as f64]),
+                )
+                .y_axis(
+                    Axis::default()
+                        .title(Span::styled(
+                            "WPM (10-keypress rolling average)",
+                            theme.results_chart_y,
+                        ))
+                        .bounds([wpm_sma_min, wpm_sma_max])
+                        .labels(
+                            (y_label_min..y_label_max)
+                                .step_by(5)
+                                .map(|n| Span::raw(format!("{}", n)))
+                                .collect(),
+                        ),
+                );
+            wpm_chart.render(res_chunks[1], buf);
+        }
     }
 }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -307,6 +307,9 @@ impl ThemedWidget for &results::Results {
             .style(theme.results_chart)
             .data(&wpm_sma)];
 
+        let y_label_min = wpm_sma_min as u16;
+        let y_label_max = (wpm_sma_max as u16).max(y_label_min + 6);
+
         let wpm_chart = Chart::new(wpm_datasets)
             .block(Block::default().title(vec![Span::styled("Chart", theme.title)]))
             .x_axis(
@@ -322,7 +325,7 @@ impl ThemedWidget for &results::Results {
                     ))
                     .bounds([wpm_sma_min, wpm_sma_max])
                     .labels(
-                        (wpm_sma_min as u16..wpm_sma_max as u16)
+                        (y_label_min..y_label_max)
                             .step_by(5)
                             .map(|n| Span::raw(format!("{}", n)))
                             .collect(),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -291,7 +291,8 @@ impl ThemedWidget for &results::Results {
             })
             .collect();
 
-        if !wpm_sma.is_empty() { // In case there's a chart to render
+        // Render the chart if possible
+        if !wpm_sma.is_empty() {
             let wpm_sma_min = wpm_sma
                 .iter()
                 .map(|(_, x)| x)


### PR DESCRIPTION
Fix #42.

The old "division by zero" error can be consistently triggered when one tests on a single word "aaaaaaaaaaaa" (12 a's). There will only be two wpm counts, and the error triggers if the difference is smaller than 5.