### PR TITLE
Add serialization of the test data to json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,6 +90,7 @@ dependencies = [
  "libc",
  "mio",
  "parking_lot",
+ "serde",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -205,6 +206,12 @@ dependencies = [
  "equivalent",
  "hashbrown",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "lazy_static"
@@ -436,6 +443,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -468,6 +481,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.37",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.107"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -651,6 +675,7 @@ dependencies = [
  "ratatui",
  "rust-embed",
  "serde",
+ "serde_json",
  "structopt",
  "toml",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,13 @@ edition = "2021"
 [dependencies]
 structopt = "^0.3"
 dirs = "^5.0"
-crossterm = "^0.26"
 rust-embed = "^6.4"
 toml = "^0.7"
+serde_json = "1.0"
+
+[dependencies.crossterm]
+version = "^0.26"
+features = ["serde"]
 
 [dependencies.ratatui]
 version = "^0.21"

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use crossterm::{
 use rand::{seq::SliceRandom, thread_rng};
 use ratatui::{backend::CrosstermBackend, terminal::Terminal};
 use rust_embed::RustEmbed;
+use serde_json;
 use std::{
     ffi::OsString,
     fs,
@@ -261,6 +262,10 @@ fn main() -> crossterm::Result<()> {
                 if let Event::Key(key) = event {
                     test.handle_key(key);
                     if test.complete {
+                        let events: Vec<&test::TestEvent> =
+                            test.words.iter().flat_map(|w| w.events.iter()).collect();
+                        let data = serde_json::to_string(&events).unwrap();
+                        fs::write("events.json", data).expect("Unable to write file");
                         state = State::Results(Results::from(&*test));
                     }
                 }

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -1,10 +1,24 @@
 pub mod results;
 
 use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+use serde::{Serialize, Serializer};
 use std::fmt;
 use std::time::Instant;
 
+pub fn serialize_instant<S>(instant: &Instant, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let duration = instant.elapsed();
+    duration.serialize(serializer)
+}
+
+#[derive(Serialize)]
 pub struct TestEvent {
+    #[serde(
+        serialize_with = "serialize_instant",
+        deserialize_with = "deserialize_instant"
+    )]
     pub time: Instant,
     pub key: KeyEvent,
     pub correct: Option<bool>,


### PR DESCRIPTION
closes #28

It has been a long time :D but I got around to implement an initial support for exporting serialized results.

This is a draft to get feedback in as soon as possible.

To do:
- [ ] Export word list as well
- [ ] Do exports on key press when viewing the results screen
- [ ] Export results after every test with a config option
- [ ] Set export location via GUI and config
- [ ] Have unique filenames
- [ ] Clean up format

Considering the resulting format I would propose to stick as close to original data structures as possible and export all available data. In my opinion this export is for experts, who want to their own analysis in a programming language.