### PR TITLE
feat: npm install -g ttyper

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -153,7 +153,7 @@ jobs:
         with:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
-      - name: Setup | Vesion
+      - name: Setup | Version
         run: npm version ${{ github.ref_name }}
         working-directory: ./npm
       - name: NPM Publish

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -140,3 +140,26 @@ jobs:
           files: |
             ttyper-*/ttyper-*
             LICENSE.md
+
+  npm-release:
+    name: NPM Publish
+    needs: github-release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup | Checkout
+        uses: actions/checkout@v4
+      - name: Setup | Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Setup | Vesion
+        run: npm version ${{ github.ref_name }}
+        working-directory: ./npm
+      - name: NPM Publish
+        run: |
+          cp ../README.md .
+          npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        working-directory: ./npm

--- a/npm/install.js
+++ b/npm/install.js
@@ -1,0 +1,129 @@
+import fs from "fs";
+import https from "https";
+import path from "path";
+import { fileURLToPath } from "url";
+
+// ESM doesn't support __dirname and __filename by default
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const packageJson = JSON.parse(fs.readFileSync("./package.json", "utf8"));
+// The version number is expected to be in parity with the ttyper release version
+const { version, repository, name, binDir: directory } = packageJson;
+
+// All the binary files will be stored in the /bin directory
+const binDir = path.join(__dirname, directory);
+console.log(`Installing ${name} v${version}`);
+
+try {
+  void install();
+} catch (error) {
+  console.error("Installation failed:", error.message);
+}
+
+async function install() {
+  if (fs.existsSync(binDir)) {
+    fs.rmSync(binDir, { recursive: true });
+  }
+  fs.mkdirSync(binDir, {
+    mode: 0o777,
+  });
+  await getBinary();
+
+  // Remove the node_modules as we'll only need the binary
+  fs.rmSync(path.join(__dirname, "node_modules"), { recursive: true });
+}
+
+function getBinaryDownloadURL() {
+  let os, arch;
+
+  // Possible values are : 'aix' | 'android' | 'darwin' | 'freebsd' | 'haiku' | 'linux' | 'openbsd' | 'sunos' | 'win32' | 'cygwin' | 'netbsd'
+  switch (process.platform) {
+    case "win32":
+    case "cygwin":
+      os = "pc-windows-msvc";
+      break;
+    case "darwin":
+      os = "apple-darwin";
+      break;
+    case "linux":
+      os = "unknown-linux-gnu";
+      break;
+    default:
+      throw new Error(`Unsupported OS: ${process.platform}`);
+  }
+
+  // Possible values are: 'arm' | 'arm64' | 'ia32' | 'mips' | 'mipsel' | 'ppc' | 'ppc64' | 's390' | 's390x' | 'x64'
+  switch (process.arch) {
+    case "x64":
+      arch = "x86_64";
+      break;
+    case "arm64":
+      arch = "aarch64";
+      break;
+    case "ia32":
+      arch = "i686";
+      break;
+    default:
+      throw new Error(`Unsupported architecture: ${process.arch}`);
+  }
+
+  const extension = os === "pc-windows-msvc" ? "zip" : "tar.gz";
+
+  return `${repository}/releases/download/v${version}/${name}-${arch}-${os}.${extension}`;
+}
+
+function downloadPackage(url, outputPath) {
+  // We use https.get instead of fetch to get a readable stream from the response without additional dependencies
+  return new Promise((resolve, reject) => {
+    https
+      .get(url, (response) => {
+        // If the response is a redirect, we download the package from the new location
+        if (response.statusCode === 302) {
+          resolve(downloadPackage(response.headers.location, outputPath));
+        } else if (response.statusCode === 200) {
+          const file = fs.createWriteStream(outputPath);
+          response.pipe(file);
+          file.on("finish", () => {
+            file.close(resolve);
+          });
+        } else {
+          reject(
+            new Error(
+              `Failed to download ${name}. Status code: ${response.statusCode}`
+            )
+          );
+        }
+      })
+      .on("error", reject);
+  });
+}
+
+async function extractPackage(inputPath, outputPath) {
+  if (path.extname(inputPath) === ".gz") {
+    const tar = await import("tar");
+    await tar.x({
+      file: inputPath,
+      cwd: outputPath,
+    });
+  } else if (path.extname(inputPath) === ".zip") {
+    const AdmZip = (await import("adm-zip")).default;
+    const zip = new AdmZip(inputPath);
+    zip.extractAllTo(outputPath, true, true);
+  }
+}
+
+async function getBinary() {
+  const downloadURL = getBinaryDownloadURL();
+  console.log(`Downloading ${name} from ${downloadURL}`);
+
+  const pkgName = ["win32", "cygwin"].includes(process.platform)
+    ? `package.zip`
+    : `package.tar.gz`;
+  const packagePath = path.join(binDir, pkgName);
+
+  await downloadPackage(downloadURL, packagePath);
+  await extractPackage(packagePath, binDir);
+
+  fs.rmSync(packagePath);
+}

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -1,0 +1,122 @@
+{
+  "name": "ttyper",
+  "version": "0.0.0-alpha2",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ttyper",
+      "version": "0.0.0-alpha2",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "adm-zip": "^0.5.10",
+        "tar": "^6.1.15"
+      },
+      "bin": {
+        "ttyper": "bin/runner.js"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.10.tgz",
+      "integrity": "sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ==",
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/fs-minipass/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minizlib/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tar": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.0.tgz",
+      "integrity": "sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    }
+  }
+}

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "ttyper",
+  "version": "0.0.0-alpha2",
+  "description": "ttyper is a terminal-based typing test built with Rust and tui-rs.",
+  "repository": "https://github.com/max-niederman/ttyper",
+  "license": "MIT",
+  "bin": {
+    "ttyper": "runner.js"
+  },
+  "type": "module",
+  "scripts": {
+    "install": "node install.js"
+  },
+  "binDir": "bin",
+  "dependencies": {
+    "adm-zip": "^0.5.10",
+    "tar": "^6.1.15"
+  }
+}

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ttyper",
-  "version": "0.0.0-alpha2",
+  "version": "0.0.0",
   "description": "ttyper is a terminal-based typing test built with Rust and tui-rs.",
   "repository": "https://github.com/max-niederman/ttyper",
   "license": "MIT",

--- a/npm/runner.js
+++ b/npm/runner.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+
+import { spawn } from "child_process";
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+// ESM doesn't support __dirname and __filename by default
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const packageJsonPath = path.join(__dirname, "package.json");
+const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+const { name, binDir } = packageJson;
+
+const commandArgs = process.argv.slice(2);
+const exeName = ["win32", "cygwin"].includes(process.platform)
+  ? `${name}.exe`
+  : name;
+const cwd = path.join(__dirname, binDir);
+const binPath = path.join(cwd, exeName);
+
+const child = spawn(binPath, commandArgs, { stdio: "inherit", cwd });


### PR DESCRIPTION
This PR intends to add `npm install -g ttyper` as an install strategy for Ttyper.

## Here's how this works:

When `npm install` is run, NPM executes the install script, i.e. `install.js`.

 The `install.js` file:
- Downloads the appropriate binary from GitHub releases and moves it to the `bin` directory.
- Removes the `node_modules` with the tar and zip libraries as they are not needed any further.
- NPM symlinks the package name `ttyper`, to whatever is set as the `bin` value in the `package.json`.
- We configure the `bin` to run `runner.js`, which handles the running of our downloaded binary.

The added `npm-release` Action job:
-  Bumps the version number value in the `package.json` to be in parity with the release version.
- Copies the `README.md` from the root dir to be displayed on the NPM homepage.
- Publishes the package to NPM.

We can commit the version bump if we need to, but that would be an unnecessary commit. The bumped version is what'll be published to NPM.  If you look at the version number in the published `package.json`, you'll see it's bumped right. https://www.npmjs.com/package/ttyper?activeTab=code.

A successful run of this workflow can be found [here](https://github.com/Anush008/ttyper/actions/runs/6762771728/job/18379124769).