### PR TITLE
Hide keys with 100% accuracy in the result view

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -334,18 +334,19 @@ impl ThemedWidget for &results::Results {
         worst_text.extend(
             worst_keys
                 .iter()
-                .take(5)
                 .filter_map(|(key, acc)| {
                     if let KeyCode::Char(character) = key.code {
-                        Some(format!(
-                            "- {} at {:.1}% accuracy",
-                            character,
-                            f64::from(**acc) * 100.0,
-                        ))
+                        let key_accuracy = f64::from(**acc) * 100.0;
+                        if key_accuracy != 100.0 {
+                            Some(format!("- {} at {:.1}% accuracy", character, key_accuracy))
+                        } else {
+                            None
+                        }
                     } else {
                         None
                     }
                 })
+                .take(5)
                 .map(Line::from),
         );
         let worst = Paragraph::new(worst_text).block(


### PR DESCRIPTION
Showing keys that are 100% accurate under _worst keys_ seems not a good choice to me and this PR hides these keys from the results view.

Closes #94 