### PR TITLE
Better error message for empty language file, implement drop for `State` to disable raw mode and other modes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -98,6 +98,10 @@ impl Opt {
                             .map(|f| f.data.into_owned())
                     })?;
 
+                if bytes.is_empty() {
+                    panic!("Language file had not content.");
+                }
+
                 let mut rng = thread_rng();
 
                 let mut language: Vec<&str> = str::from_utf8(&bytes)


### PR DESCRIPTION
This PR adds an error message for zero-length files and implements the `Drop` trait for `State` to ensure that the raw mode is disabled the cursor position is restored and the cursor is shown.

Closes #78