### PR TITLE
New feature: sudden death

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ mod test;
 mod ui;
 
 use config::Config;
-use test::{is_missed_word_event, results::Results, Test};
+use test::{results::Results, Test};
 
 use crossterm::{
     self, cursor,
@@ -267,25 +267,6 @@ fn main() -> io::Result<()> {
                     test.handle_key(key);
                     if test.complete {
                         state = State::Results(Results::from(&*test));
-                    } else if test.sudden_death_enabled {
-                        if test.words[test.current_word]
-                            .events
-                            .last()
-                            .is_some_and(is_missed_word_event)
-                            || test.current_word > 0
-                                && test.words[test.current_word - 1]
-                                    .events
-                                    .last()
-                                    .is_some_and(is_missed_word_event)
-                        {
-                            state = State::Test(Test::new(
-                                    opt.gen_contents().expect(
-                                        "Couldn't get test contents. Make sure the specified language actually exists.",
-                                        ),
-                                        !opt.no_backtrack,
-                                        opt.sudden_death
-                                        ));
-                        }
                     }
                 }
             }

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -11,7 +11,7 @@ pub struct TestEvent {
 }
 
 pub fn is_missed_word_event(event: &TestEvent) -> bool {
-    event.correct == Some(false) || event.correct.is_none()
+    event.correct != Some(true)
 }
 
 impl fmt::Debug for TestEvent {

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -10,6 +10,10 @@ pub struct TestEvent {
     pub correct: Option<bool>,
 }
 
+pub fn is_missed_word_event(event: &TestEvent) -> bool {
+    event.correct == Some(false) || event.correct.is_none()
+}
+
 impl fmt::Debug for TestEvent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("TestEvent")
@@ -48,15 +52,17 @@ pub struct Test {
     pub current_word: usize,
     pub complete: bool,
     pub backtracking_enabled: bool,
+    pub sudden_death_enabled: bool,
 }
 
 impl Test {
-    pub fn new(words: Vec<String>, backtracking_enabled: bool) -> Self {
+    pub fn new(words: Vec<String>, backtracking_enabled: bool, sudden_death_enabled: bool) -> Self {
         Self {
             words: words.into_iter().map(TestWord::from).collect(),
             current_word: 0,
             complete: false,
             backtracking_enabled,
+            sudden_death_enabled,
         }
     }
 

--- a/src/test/results.rs
+++ b/src/test/results.rs
@@ -1,4 +1,4 @@
-use super::Test;
+use super::{is_missed_word_event, Test};
 
 use crossterm::event::KeyEvent;
 use std::collections::HashMap;
@@ -150,10 +150,6 @@ fn calc_accuracy(events: &[&super::TestEvent]) -> AccuracyData {
 }
 
 fn calc_missed_words(test: &Test) -> Vec<String> {
-    let is_missed_word_event = |event: &super::TestEvent| -> bool {
-        event.correct == Some(false) || event.correct.is_none()
-    };
-
     test.words
         .iter()
         .filter(|word| word.events.iter().any(is_missed_word_event))


### PR DESCRIPTION
Adds an optional "sudden death mode" to `ttyper`, so that it will restart the current test as soon as the user makes a mistake.
To enable sudden death mode, start `ttyper` with the flag `--sudden-death`, e.g.:

```console
ttyper --sudden-death
```

Addresses #108 