### PR TITLE
docs(readme): add instructions for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ Pre-built binaries are available for most architectures on [GitHub releases](htt
 cargo install ttyper
 ```
 
+### arch linux
+
+```bash
+pacman -S ttyper
+```
+
 ### scoop
 
 ```bash


### PR DESCRIPTION
`ttyper` is now available in the Arch Linux repository: https://archlinux.org/packages/extra/x86_64/ttyper/
