### PR TITLE
Bumps libc from 0.2.153 to 0.2.155

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,9 +310,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libredox"


### PR DESCRIPTION
Add dependencies that support the loongarch64 architecture
https://github.com/rust-lang/libc/pull/2765