### PR TITLE
fix: fix terminal breaking on no invalid language

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -218,6 +218,9 @@ fn main() -> io::Result<()> {
 
     let backend = CrosstermBackend::new(io::stdout());
     let mut terminal = Terminal::new(backend)?;
+    let contents = opt
+        .gen_contents()
+        .expect("Couldn't get test contents. Make sure the specified language actually exists.");
 
     terminal::enable_raw_mode()?;
     execute!(
@@ -228,13 +231,7 @@ fn main() -> io::Result<()> {
     )?;
     terminal.clear()?;
 
-    let mut state = State::Test(Test::new(
-        opt.gen_contents().expect(
-            "Couldn't get test contents. Make sure the specified language actually exists.",
-        ),
-        !opt.no_backtrack,
-        opt.sudden_death,
-    ));
+    let mut state = State::Test(Test::new(contents, !opt.no_backtrack, opt.sudden_death));
 
     state.render_into(&mut terminal, &config)?;
     loop {

--- a/src/test/results.rs
+++ b/src/test/results.rs
@@ -43,19 +43,6 @@ impl fmt::Display for Fraction {
     }
 }
 
-pub trait PartialResults {
-    fn progress(&self) -> Fraction;
-}
-
-impl PartialResults for Test {
-    fn progress(&self) -> Fraction {
-        Fraction {
-            numerator: self.current_word + 1,
-            denominator: self.words.len(),
-        }
-    }
-}
-
 pub struct TimingData {
     // Instead of storing WPM, we store CPS (clicks per second)
     pub overall_cps: f64,


### PR DESCRIPTION
This commit fixes the terminal breaking on invalid language entry in config. Also, partialresult is removed as a part of linting.