### PR TITLE
docs(readme): add fedora ttyper package from copr repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,13 @@ nix-env -iA nixpkgs.ttyper # or nixos.ttyper on NixOS
 scoop install ttyper
 ```
 
+### fedora
+
+```bash
+dnf copr enable protocod/ttyper # add copr repository
+dnf install ttyper
+```
+
 ## usage
 
 For usage instructions, you can run `ttyper --help`:


### PR DESCRIPTION
Hi,
I'm packaging `ttyper` for fedora using copr.
I succeed to package the crate on latest fedora stable. (currently 41)

Of course copr is community driven like AUR with Archlinux. I'm not a fedora package maintainer, so my copr repository provide an unofficial way to get `ttyper` for fedora because I'm just a simple fedora user.

That said, I'm interested to maintain your crate in my copr repository. However I fully understand if you don't want to share a link to a copr repository in the README.md. Feel free to refuse this PR.