### PR TITLE
(Vibe Coded) Add --raw and --qwerty flags for typing arbitrary files. Scroll for long texts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,14 @@ USAGE:
     ttyper [FLAGS] [OPTIONS] [contents]
 
 FLAGS:
-    -d, --debug             
+    -d, --debug
     -h, --help              Prints help information
         --list-languages    List installed languages
         --no-backtrack      Disable backtracking to completed words
         --sudden-death      Enable sudden death mode to restart on first error
         --no-backspace      Disable backspace
+        --raw               Treat input as raw text: preserve line layout, indentation, and empty lines
+        --qwerty            Display all UTF-8 but skip non-ASCII-printable characters during typing
     -V, --version           Prints version information
 
 OPTIONS:
@@ -77,13 +79,39 @@ ARGS:
 
 ### examples
 
-| command                        |                             test contents |
-| :----------------------------- | ----------------------------------------: |
-| `ttyper`                       |   50 of the 200 most common english words |
-| `ttyper -w 100`                |  100 of the 200 most common English words |
-| `ttyper -w 100 -l english1000` | 100 of the 1000 most common English words |
-| `ttyper --language-file lang`  |      50 random words from the file `lang` |
-| `ttyper text.txt`              |  contents of `text.txt` split at newlines |
+| command                                  |                                          test contents |
+| :--------------------------------------- | ------------------------------------------------------: |
+| `ttyper`                                 |                50 of the 200 most common english words |
+| `ttyper -w 100`                          |               100 of the 200 most common English words |
+| `ttyper -w 100 -l english1000`           |              100 of the 1000 most common English words |
+| `ttyper --language-file lang`            |                   50 random words from the file `lang` |
+| `ttyper text.txt`                        |               contents of `text.txt` split at newlines |
+| `ttyper --raw text.txt`                  |    contents of `text.txt` with original line layout    |
+| `ttyper --raw --qwerty source.rs`        | type a source file, skipping non-ASCII characters      |
+| `man ls \| ttyper --raw --qwerty -`      |         practice typing a man page from stdin          |
+
+### raw mode
+
+By default, ttyper treats each line of a file as a single word. The `--raw` flag changes this to preserve the original formatting of the input file:
+
+- Lines are displayed with their original line breaks and indentation
+- Tabs are expanded to 4 spaces
+- Empty lines are preserved in the display
+- Words are split on whitespace, as they would appear in the file
+- Control characters are stripped from word content
+
+This is useful for practicing with source code, man pages, or any structured text where layout matters.
+
+### qwerty mode
+
+The `--qwerty` flag is designed for typing files that contain Unicode or other non-ASCII characters (e.g. smart quotes, em dashes, accented characters). With this flag:
+
+- All UTF-8 characters are displayed in the prompt
+- Non-ASCII-printable characters are highlighted in yellow and the cursor skips over them
+- The user only needs to type the ASCII-printable portion of each word
+- Words that are entirely non-typeable (e.g. "---") are auto-skipped
+
+This pairs well with `--raw` for practicing with real-world text that may contain typographic characters your keyboard can't produce.
 
 ## languages
 
@@ -171,6 +199,9 @@ prompt_current_untyped = "blue;bold"
 
 # cursor character
 prompt_cursor = "none;underlined"
+
+# skipped non-typeable characters (--qwerty mode)
+prompt_skipped = "yellow"
 
 ## results styles ##
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -57,6 +57,9 @@ pub struct Theme {
     #[serde(deserialize_with = "deserialize_style")]
     pub prompt_cursor: Style,
 
+    #[serde(deserialize_with = "deserialize_style")]
+    pub prompt_skipped: Style,
+
     // results widget
     #[serde(deserialize_with = "deserialize_style")]
     pub results_overview: Style,
@@ -106,6 +109,8 @@ impl Default for Theme {
                 .add_modifier(Modifier::BOLD),
 
             prompt_cursor: Style::default().add_modifier(Modifier::UNDERLINED),
+
+            prompt_skipped: Style::default().fg(Color::Yellow),
 
             results_overview: Style::default()
                 .fg(Color::Cyan)

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ mod test;
 mod ui;
 
 use config::Config;
-use test::{results::Results, Test};
+use test::{results::Results, DisplayLine, Test};
 
 use clap::{CommandFactory, Parser, Subcommand};
 use clap_complete::{generate, Shell};
@@ -22,7 +22,7 @@ use rust_embed::RustEmbed;
 use std::{
     ffi::OsString,
     fs,
-    io::{self, BufRead},
+    io::{self, BufRead, Read},
     num,
     path::PathBuf,
     str,
@@ -74,6 +74,14 @@ struct Opt {
     #[arg(long)]
     no_backspace: bool,
 
+    /// Treat input as raw text: split into words and preserve line layout
+    #[arg(long)]
+    raw: bool,
+
+    /// Display all UTF-8 but skip non-ASCII-printable characters during typing
+    #[arg(long)]
+    qwerty: bool,
+
     #[command(subcommand)]
     command: Option<Command>,
 }
@@ -88,24 +96,76 @@ enum Command {
 }
 
 impl Opt {
-    fn gen_contents(&self) -> Option<Vec<String>> {
+    /// Generate test contents.
+    ///
+    /// Returns `(words, lines)` where `lines` describes the original file
+    /// layout (empty for language/word-list mode).
+    fn gen_contents(&self) -> Option<(Vec<String>, Vec<DisplayLine>)> {
         match &self.contents {
             Some(path) => {
-                let lines: Vec<String> = if path.as_os_str() == "-" {
-                    std::io::stdin()
-                        .lock()
-                        .lines()
-                        .map_while(Result::ok)
-                        .collect()
-                } else {
-                    let file = fs::File::open(path).expect("Error reading language file.");
-                    io::BufReader::new(file)
-                        .lines()
-                        .map_while(Result::ok)
-                        .collect()
-                };
+                if self.raw {
+                    // Raw mode: split into words, preserve line structure
+                    // including empty lines and indentation.
+                    let text = if path.as_os_str() == "-" {
+                        let mut buf = String::new();
+                        std::io::stdin()
+                            .lock()
+                            .read_to_string(&mut buf)
+                            .expect("Error reading from stdin.");
+                        buf
+                    } else {
+                        fs::read_to_string(path).expect("Error reading file.")
+                    };
 
-                Some(lines.iter().map(String::from).collect())
+                    let mut words = Vec::new();
+                    let mut lines = Vec::new();
+
+                    for line in text.lines() {
+                        // Capture leading whitespace, expand tabs to 4 spaces
+                        let indent: String = line
+                            .chars()
+                            .take_while(|c| c.is_whitespace())
+                            .collect::<String>()
+                            .replace('\t', "    ");
+
+                        let word_start = words.len();
+                        for token in line.split_whitespace() {
+                            // Strip control characters, keep all printable chars
+                            let word: String =
+                                token.chars().filter(|c| !c.is_control()).collect();
+                            if !word.is_empty() {
+                                words.push(word);
+                            }
+                        }
+                        let word_count = words.len() - word_start;
+
+                        lines.push(DisplayLine {
+                            indent,
+                            word_start,
+                            word_count,
+                        });
+                    }
+
+                    Some((words, lines))
+                } else {
+                    // Default: each line is one word (original behavior).
+                    let lines: Vec<String> = if path.as_os_str() == "-" {
+                        std::io::stdin()
+                            .lock()
+                            .lines()
+                            .map_while(Result::ok)
+                            .collect()
+                    } else {
+                        let file =
+                            fs::File::open(path).expect("Error reading language file.");
+                        io::BufReader::new(file)
+                            .lines()
+                            .map_while(Result::ok)
+                            .collect()
+                    };
+
+                    Some((lines, Vec::new()))
+                }
             }
             None => {
                 let lang_name = self
@@ -140,7 +200,7 @@ impl Opt {
                     .collect();
                 contents.shuffle(&mut rng);
 
-                Some(contents)
+                Some((contents, Vec::new()))
             }
         }
     }
@@ -209,9 +269,14 @@ impl State {
                     f.render_widget(config.theme.apply_to(test), area);
 
                     // Position cursor at end of input for IME composition support
+                    let prompt_constraint = if !test.lines.is_empty() {
+                        Constraint::Min(6)
+                    } else {
+                        Constraint::Length(6)
+                    };
                     let chunks = Layout::default()
                         .direction(Direction::Vertical)
-                        .constraints([Constraint::Length(3), Constraint::Length(6)])
+                        .constraints([Constraint::Length(3), prompt_constraint])
                         .split(area);
                     let inner_x = chunks[0].x + 1;
                     let inner_y = chunks[0].y + 1;
@@ -258,7 +323,7 @@ fn main() -> io::Result<()> {
 
     let backend = CrosstermBackend::new(io::stdout());
     let mut terminal = Terminal::new(backend)?;
-    let contents = opt
+    let (contents, lines) = opt
         .gen_contents()
         .expect("Couldn't get test contents. Make sure the specified language actually exists.");
 
@@ -282,6 +347,8 @@ fn main() -> io::Result<()> {
         !opt.no_backtrack,
         opt.sudden_death,
         !opt.no_backspace,
+        lines,
+        opt.qwerty,
     ));
 
     state.render_into(&mut terminal, &config)?;
@@ -326,7 +393,7 @@ fn main() -> io::Result<()> {
                     modifiers: KeyModifiers::NONE,
                     ..
                 }) => {
-                    let new_contents = opt.gen_contents().expect(
+                    let (new_contents, new_lines) = opt.gen_contents().expect(
                         "Couldn't get test contents. Make sure the specified language actually exists.",
                     );
                     if new_contents.is_empty() {
@@ -337,6 +404,8 @@ fn main() -> io::Result<()> {
                         !opt.no_backtrack,
                         opt.sudden_death,
                         !opt.no_backspace,
+                        new_lines,
+                        opt.qwerty,
                     ));
                 }
                 Event::Key(KeyEvent {
@@ -359,6 +428,8 @@ fn main() -> io::Result<()> {
                         !opt.no_backtrack,
                         opt.sudden_death,
                         !opt.no_backspace,
+                        Vec::new(),
+                        opt.qwerty,
                     ));
                 }
                 Event::Key(KeyEvent {
@@ -390,7 +461,7 @@ mod tests {
     use super::*;
     use std::io::Write;
 
-    fn make_opt(path: PathBuf) -> Opt {
+    fn make_opt(path: PathBuf, raw: bool, qwerty: bool) -> Opt {
         Opt {
             contents: Some(path),
             debug: false,
@@ -402,6 +473,8 @@ mod tests {
             no_backtrack: false,
             sudden_death: false,
             no_backspace: false,
+            raw,
+            qwerty,
             command: None,
         }
     }
@@ -412,18 +485,151 @@ mod tests {
         let path = dir.path().join("empty.txt");
         fs::File::create(&path).unwrap();
 
-        let contents = make_opt(path).gen_contents().unwrap();
+        let (contents, _) = make_opt(path, false, false).gen_contents().unwrap();
         assert!(contents.is_empty(), "empty file should produce empty vec");
     }
 
     #[test]
-    fn gen_contents_nonempty_file_returns_words() {
+    fn gen_contents_default_lines_as_words() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("words.txt");
         let mut f = fs::File::create(&path).unwrap();
         writeln!(f, "hello world rust").unwrap();
 
-        let contents = make_opt(path).gen_contents().unwrap();
-        assert!(!contents.is_empty(), "non-empty file should produce words");
+        let (contents, lines) = make_opt(path, false, false).gen_contents().unwrap();
+        assert_eq!(contents, vec!["hello world rust"]);
+        assert!(lines.is_empty());
+    }
+
+    #[test]
+    fn gen_contents_raw_splits_words() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("words.txt");
+        let mut f = fs::File::create(&path).unwrap();
+        writeln!(f, "hello world rust").unwrap();
+
+        let (contents, lines) = make_opt(path, true, false).gen_contents().unwrap();
+        assert_eq!(contents, vec!["hello", "world", "rust"]);
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0].word_start, 0);
+        assert_eq!(lines[0].word_count, 3);
+    }
+
+    #[test]
+    fn gen_contents_raw_preserves_unicode() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("unicode.txt");
+        let mut f = fs::File::create(&path).unwrap();
+        writeln!(f, "hello\u{2014}world \u{201c}quoted\u{201d}").unwrap();
+
+        let (contents, _) = make_opt(path, true, false).gen_contents().unwrap();
+        assert_eq!(contents, vec!["hello\u{2014}world", "\u{201c}quoted\u{201d}"]);
+    }
+
+    #[test]
+    fn gen_contents_raw_multiline_tracks_lines() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("multi.txt");
+        let mut f = fs::File::create(&path).unwrap();
+        write!(f, "first line\nsecond line\n\nfourth line").unwrap();
+
+        let (contents, lines) = make_opt(path, true, false).gen_contents().unwrap();
+        assert_eq!(
+            contents,
+            vec!["first", "line", "second", "line", "fourth", "line"]
+        );
+        // 4 lines: line 1, line 2, empty line, line 4
+        assert_eq!(lines.len(), 4);
+        assert_eq!((lines[0].word_start, lines[0].word_count), (0, 2));
+        assert_eq!((lines[1].word_start, lines[1].word_count), (2, 2));
+        assert_eq!(lines[2].word_count, 0); // empty line preserved
+        assert_eq!((lines[3].word_start, lines[3].word_count), (4, 2));
+    }
+
+    #[test]
+    fn gen_contents_raw_empty_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("empty.txt");
+        fs::File::create(&path).unwrap();
+
+        let (contents, lines) = make_opt(path, true, false).gen_contents().unwrap();
+        assert!(contents.is_empty());
+        assert!(lines.is_empty());
+    }
+
+    #[test]
+    fn gen_contents_raw_preserves_whitespace_only_lines() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("spaces.txt");
+        let mut f = fs::File::create(&path).unwrap();
+        write!(f, "hello\n   \n  \t  \nworld").unwrap();
+
+        let (contents, lines) = make_opt(path, true, false).gen_contents().unwrap();
+        assert_eq!(contents, vec!["hello", "world"]);
+        // 4 lines total: "hello", whitespace-only, whitespace-only, "world"
+        assert_eq!(lines.len(), 4);
+        assert_eq!(lines[0].word_count, 1);
+        assert_eq!(lines[1].word_count, 0); // whitespace-only preserved
+        assert_eq!(lines[2].word_count, 0);
+        assert_eq!(lines[3].word_count, 1);
+    }
+
+    #[test]
+    fn gen_contents_raw_keeps_all_unicode_tokens() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("alluni.txt");
+        let mut f = fs::File::create(&path).unwrap();
+        write!(f, "hello \u{2014}\u{2014}\u{2014} world").unwrap();
+
+        let (contents, _) = make_opt(path, true, false).gen_contents().unwrap();
+        assert_eq!(contents, vec!["hello", "\u{2014}\u{2014}\u{2014}", "world"]);
+    }
+
+    #[test]
+    fn gen_contents_default_multiline_each_line_is_word() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("multi.txt");
+        let mut f = fs::File::create(&path).unwrap();
+        write!(f, "first line\nsecond line").unwrap();
+
+        let (contents, lines) = make_opt(path, false, false).gen_contents().unwrap();
+        assert_eq!(contents, vec!["first line", "second line"]);
+        assert!(lines.is_empty());
+    }
+
+    #[test]
+    fn gen_contents_raw_preserves_punctuation() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("punct.txt");
+        let mut f = fs::File::create(&path).unwrap();
+        write!(f, "it's a \"test\" (100%); done!").unwrap();
+
+        let (contents, _) = make_opt(path, true, false).gen_contents().unwrap();
+        assert_eq!(contents, vec!["it's", "a", "\"test\"", "(100%);", "done!"]);
+    }
+
+    #[test]
+    fn gen_contents_raw_expands_tabs_in_indent() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("tabs.txt");
+        let mut f = fs::File::create(&path).unwrap();
+        write!(f, "hello\n\tindented\n\t\tdeep").unwrap();
+
+        let (contents, lines) = make_opt(path, true, false).gen_contents().unwrap();
+        assert_eq!(contents, vec!["hello", "indented", "deep"]);
+        assert_eq!(lines[0].indent, "");
+        assert_eq!(lines[1].indent, "    ");      // 1 tab = 4 spaces
+        assert_eq!(lines[2].indent, "        ");  // 2 tabs = 8 spaces
+    }
+
+    #[test]
+    fn gen_contents_raw_strips_control_chars_from_words() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ctrl.txt");
+        let mut f = fs::File::create(&path).unwrap();
+        write!(f, "hel\x07lo wor\x00ld").unwrap();
+
+        let (contents, _) = make_opt(path, true, false).gen_contents().unwrap();
+        assert_eq!(contents, vec!["hello", "world"]);
     }
 }

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -4,6 +4,22 @@ use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use std::fmt;
 use std::time::Instant;
 
+/// Returns true if a character is typeable on a standard US QWERTY keyboard
+/// (printable ASCII: space through tilde, 0x20–0x7E).
+pub fn is_typeable(c: char) -> bool {
+    c.is_ascii() && !c.is_ascii_control()
+}
+
+/// Returns the typeable portion of `text`.
+/// When `qwerty` is false the full text is returned unchanged.
+fn target_text(text: &str, qwerty: bool) -> String {
+    if qwerty {
+        text.chars().filter(|c| is_typeable(*c)).collect()
+    } else {
+        text.to_string()
+    }
+}
+
 pub struct TestEvent {
     pub time: Instant,
     pub key: KeyEvent,
@@ -46,6 +62,17 @@ impl From<&str> for TestWord {
     }
 }
 
+/// A line of the original file, used in raw mode for display.
+#[derive(Debug, Clone)]
+pub struct DisplayLine {
+    /// Leading whitespace (tabs expanded to 4 spaces).
+    pub indent: String,
+    /// Index of the first word on this line in `Test::words`.
+    pub word_start: usize,
+    /// Number of words on this line (0 for empty/whitespace-only lines).
+    pub word_count: usize,
+}
+
 #[derive(Debug)]
 pub struct Test {
     pub words: Vec<TestWord>,
@@ -54,6 +81,10 @@ pub struct Test {
     pub backtracking_enabled: bool,
     pub sudden_death_enabled: bool,
     pub backspace_enabled: bool,
+    /// Original line layout for raw/file mode (empty = word-wrap mode).
+    pub lines: Vec<DisplayLine>,
+    /// When true, non-typeable characters are skipped during typing.
+    pub qwerty: bool,
 }
 
 impl Test {
@@ -62,15 +93,21 @@ impl Test {
         backtracking_enabled: bool,
         sudden_death_enabled: bool,
         backspace_enabled: bool,
+        lines: Vec<DisplayLine>,
+        qwerty: bool,
     ) -> Self {
-        Self {
+        let mut test = Self {
             words: words.into_iter().map(TestWord::from).collect(),
             current_word: 0,
             complete: false,
             backtracking_enabled,
             sudden_death_enabled,
             backspace_enabled,
-        }
+            lines,
+            qwerty,
+        };
+        test.skip_non_typeable_words();
+        test
     }
 
     pub fn handle_key(&mut self, key: KeyEvent) {
@@ -78,18 +115,20 @@ impl Test {
             return;
         }
 
+        let qwerty = self.qwerty;
         let word = &mut self.words[self.current_word];
+        let target = target_text(&word.text, qwerty);
         match key.code {
             KeyCode::Char(' ') | KeyCode::Enter => {
-                if word.text.chars().nth(word.progress.len()) == Some(' ') {
+                if target.chars().nth(word.progress.len()) == Some(' ') {
                     word.progress.push(' ');
                     word.events.push(TestEvent {
                         time: Instant::now(),
                         correct: Some(true),
                         key,
                     })
-                } else if !word.progress.is_empty() || word.text.is_empty() {
-                    let correct = word.text == word.progress;
+                } else if !word.progress.is_empty() || target.is_empty() {
+                    let correct = target == word.progress;
                     if self.sudden_death_enabled && !correct {
                         self.reset();
                     } else {
@@ -99,6 +138,7 @@ impl Test {
                             key,
                         });
                         self.next_word();
+                        self.skip_non_typeable_words();
                     }
                 }
             }
@@ -108,7 +148,7 @@ impl Test {
                 } else if self.backspace_enabled {
                     word.events.push(TestEvent {
                         time: Instant::now(),
-                        correct: Some(!word.text.starts_with(&word.progress[..])),
+                        correct: Some(!target.starts_with(&word.progress[..])),
                         key,
                     });
                     word.progress.pop();
@@ -133,7 +173,7 @@ impl Test {
             }
             KeyCode::Char(c) => {
                 word.progress.push(c);
-                let correct = word.text.starts_with(&word.progress[..]);
+                let correct = target.starts_with(&word.progress[..]);
                 if self.sudden_death_enabled && !correct {
                     self.reset();
                 } else {
@@ -142,7 +182,7 @@ impl Test {
                         correct: Some(correct),
                         key,
                     });
-                    if word.progress == word.text && self.current_word == self.words.len() - 1 {
+                    if word.progress == target && self.current_word == self.words.len() - 1 {
                         self.complete = true;
                         self.current_word = 0;
                     }
@@ -174,5 +214,173 @@ impl Test {
         });
         self.current_word = 0;
         self.complete = false;
+        self.skip_non_typeable_words();
+    }
+
+    fn skip_non_typeable_words(&mut self) {
+        if !self.qwerty || self.complete {
+            return;
+        }
+        loop {
+            let t = target_text(&self.words[self.current_word].text, true);
+            if !t.is_empty() {
+                break;
+            }
+            self.next_word();
+            if self.complete {
+                break;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::KeyEventState;
+
+    fn make_test(words: &[&str], lines: Vec<DisplayLine>, qwerty: bool) -> Test {
+        Test::new(
+            words.iter().map(|s| s.to_string()).collect(),
+            true,
+            false,
+            true,
+            lines,
+            qwerty,
+        )
+    }
+
+    fn press(c: char) -> KeyEvent {
+        KeyEvent {
+            code: KeyCode::Char(c),
+            modifiers: KeyModifiers::NONE,
+            kind: KeyEventKind::Press,
+            state: KeyEventState::NONE,
+        }
+    }
+
+    fn press_space() -> KeyEvent {
+        KeyEvent {
+            code: KeyCode::Char(' '),
+            modifiers: KeyModifiers::NONE,
+            kind: KeyEventKind::Press,
+            state: KeyEventState::NONE,
+        }
+    }
+
+    #[test]
+    fn new_preserves_lines() {
+        let lines = vec![
+            DisplayLine { indent: String::new(), word_start: 0, word_count: 2 },
+            DisplayLine { indent: String::new(), word_start: 2, word_count: 2 },
+        ];
+        let test = make_test(&["a", "b", "c", "d"], lines.clone(), false);
+        assert_eq!(test.lines.len(), 2);
+        assert_eq!(test.lines[0].word_start, 0);
+        assert_eq!(test.lines[1].word_start, 2);
+        assert_eq!(test.words.len(), 4);
+    }
+
+    #[test]
+    fn new_empty_lines_for_word_mode() {
+        let test = make_test(&["hello", "world"], Vec::new(), false);
+        assert!(test.lines.is_empty());
+    }
+
+    #[test]
+    fn reset_preserves_lines() {
+        let lines = vec![
+            DisplayLine { indent: String::new(), word_start: 0, word_count: 1 },
+            DisplayLine { indent: String::new(), word_start: 1, word_count: 2 },
+        ];
+        let mut test = make_test(&["a", "b", "c"], lines, false);
+        test.words[0].progress = "a".to_string();
+        test.current_word = 1;
+        test.words[1].progress = "x".to_string();
+
+        test.reset();
+
+        assert_eq!(test.current_word, 0);
+        assert!(!test.complete);
+        assert!(test.words.iter().all(|w| w.progress.is_empty()));
+        assert_eq!(test.lines.len(), 2);
+    }
+
+    #[test]
+    fn target_text_without_qwerty() {
+        assert_eq!(target_text("caf\u{00e9}", false), "caf\u{00e9}");
+    }
+
+    #[test]
+    fn target_text_with_qwerty() {
+        assert_eq!(target_text("caf\u{00e9}", true), "caf");
+        assert_eq!(target_text("hello\u{2014}world", true), "helloworld");
+        assert_eq!(target_text("\u{201c}quoted\u{201d}", true), "quoted");
+    }
+
+    #[test]
+    fn qwerty_skips_unicode_in_typing() {
+        let mut test = make_test(&["caf\u{00e9}"], Vec::new(), true);
+        for c in "caf".chars() {
+            test.handle_key(press(c));
+        }
+        assert!(test.complete);
+    }
+
+    #[test]
+    fn qwerty_space_advances_past_unicode_word() {
+        let mut test = make_test(&["caf\u{00e9}", "ok"], Vec::new(), true);
+        for c in "caf".chars() {
+            test.handle_key(press(c));
+        }
+        test.handle_key(press_space());
+        assert_eq!(test.current_word, 1);
+    }
+
+    #[test]
+    fn qwerty_auto_skips_all_unicode_word() {
+        let test = make_test(&["\u{2014}\u{2014}", "ok"], Vec::new(), true);
+        // entirely non-typeable word is auto-skipped at construction
+        assert_eq!(test.current_word, 1);
+    }
+
+    #[test]
+    fn qwerty_auto_skips_chain_of_unicode_words() {
+        let test = make_test(&["\u{2014}", "\u{00e9}\u{00e9}", "ok"], Vec::new(), true);
+        // both non-typeable words skipped at construction
+        assert_eq!(test.current_word, 2);
+    }
+
+    #[test]
+    fn qwerty_auto_skips_after_space() {
+        let mut test = make_test(&["hi", "\u{2014}", "ok"], Vec::new(), true);
+        for c in "hi".chars() {
+            test.handle_key(press(c));
+        }
+        test.handle_key(press_space());
+        // skipped past the non-typeable word to "ok"
+        assert_eq!(test.current_word, 2);
+    }
+
+    #[test]
+    fn qwerty_all_non_typeable_completes() {
+        let test = make_test(&["\u{2014}", "\u{00e9}"], Vec::new(), true);
+        assert!(test.complete);
+    }
+
+    #[test]
+    fn without_qwerty_unicode_must_be_typed() {
+        let mut test = make_test(&["caf\u{00e9}"], Vec::new(), false);
+        for c in "caf".chars() {
+            test.handle_key(press(c));
+        }
+        assert!(!test.complete);
+    }
+
+    #[test]
+    fn without_qwerty_no_auto_skip() {
+        let test = make_test(&["\u{2014}", "ok"], Vec::new(), false);
+        // without qwerty, no auto-skipping
+        assert_eq!(test.current_word, 0);
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -78,10 +78,17 @@ impl ThemedWidget for &Test {
     fn render(self, area: Rect, buf: &mut Buffer, theme: &Theme) {
         buf.set_style(area, theme.default);
 
+        // Use flexible prompt height in file mode so more text is visible
+        let prompt_constraint = if !self.lines.is_empty() {
+            Constraint::Min(6)
+        } else {
+            Constraint::Length(6)
+        };
+
         // Chunks
         let chunks = Layout::default()
             .direction(Direction::Vertical)
-            .constraints([Constraint::Length(3), Constraint::Length(6)])
+            .constraints([Constraint::Length(3), prompt_constraint])
             .split(area);
 
         // Sections
@@ -100,27 +107,62 @@ impl ThemedWidget for &Test {
         input.render(buf);
 
         let target_lines: Vec<Line> = {
-            let words = words_to_spans(&self.words, self.current_word, theme);
+            let words = words_to_spans(&self.words, self.current_word, theme, self.qwerty);
 
-            let mut lines: Vec<Line> = Vec::new();
-            let mut current_line: Vec<Span> = Vec::new();
-            let mut current_width = 0;
-            for word in words {
-                let word_width: usize = word.iter().map(|s| s.width()).sum();
-
-                if current_width + word_width > chunks[1].width as usize - 2 {
-                    current_line.push(Span::raw("\n"));
-                    lines.push(Line::from(current_line.clone()));
-                    current_line.clear();
-                    current_width = 0;
+            if !self.lines.is_empty() {
+                // File mode: preserve original line structure with indentation
+                let mut display: Vec<Line> = Vec::new();
+                for dl in &self.lines {
+                    if dl.word_count == 0 {
+                        // Empty line
+                        display.push(Line::from(""));
+                    } else {
+                        let mut line_spans: Vec<Span> = Vec::new();
+                        if !dl.indent.is_empty() {
+                            line_spans.push(Span::raw(dl.indent.clone()));
+                        }
+                        let end = dl.word_start + dl.word_count;
+                        for word in &words[dl.word_start..end] {
+                            line_spans.extend(word.iter().cloned());
+                        }
+                        display.push(Line::from(line_spans));
+                    }
                 }
 
-                current_line.extend(word);
-                current_width += word_width;
-            }
-            lines.push(Line::from(current_line));
+                // Scroll to keep the current line visible
+                let available = chunks[1].height.saturating_sub(2) as usize;
+                let current_line_idx = self
+                    .lines
+                    .iter()
+                    .position(|dl| {
+                        dl.word_count > 0
+                            && self.current_word >= dl.word_start
+                            && self.current_word < dl.word_start + dl.word_count
+                    })
+                    .unwrap_or(0);
+                let scroll = current_line_idx.saturating_sub(available / 2);
+                display.into_iter().skip(scroll).take(available).collect()
+            } else {
+                // Language mode: wrap words at terminal width
+                let mut lines: Vec<Line> = Vec::new();
+                let mut current_line: Vec<Span> = Vec::new();
+                let mut current_width = 0;
+                for word in words {
+                    let word_width: usize = word.iter().map(|s| s.width()).sum();
 
-            lines
+                    if current_width + word_width > chunks[1].width as usize - 2 {
+                        current_line.push(Span::raw("\n"));
+                        lines.push(Line::from(current_line.clone()));
+                        current_line.clear();
+                        current_width = 0;
+                    }
+
+                    current_line.extend(word);
+                    current_width += word_width;
+                }
+                lines.push(Line::from(current_line));
+                lines
+            }
         };
         let target = Paragraph::new(target_lines).block(
             Block::default()
@@ -137,15 +179,16 @@ fn words_to_spans<'a>(
     words: &'a [TestWord],
     current_word: usize,
     theme: &'a Theme,
+    qwerty: bool,
 ) -> Vec<Vec<Span<'a>>> {
     let mut spans = Vec::new();
 
     for word in &words[..current_word] {
-        let parts = split_typed_word(word);
+        let parts = split_typed_word(word, qwerty);
         spans.push(word_parts_to_spans(parts, theme));
     }
 
-    let parts_current = split_current_word(&words[current_word]);
+    let parts_current = split_current_word(&words[current_word], qwerty);
     spans.push(word_parts_to_spans(parts_current, theme));
 
     for word in &words[current_word + 1..] {
@@ -165,15 +208,34 @@ enum Status {
     Cursor,
     Untyped,
     Overtyped,
+    Skipped,
 }
 
-fn split_current_word(word: &TestWord) -> Vec<(String, Status)> {
+fn split_current_word(word: &TestWord, qwerty: bool) -> Vec<(String, Status)> {
+    use super::test::is_typeable;
+
     let mut parts = Vec::new();
     let mut cur_string = String::new();
     let mut cur_status = Status::Untyped;
 
     let mut progress = word.progress.chars();
     for tc in word.text.chars() {
+        // In qwerty mode, non-typeable chars are displayed but skipped over
+        if qwerty && !is_typeable(tc) {
+            let status = Status::Skipped;
+            if status == cur_status {
+                cur_string.push(tc);
+            } else {
+                if !cur_string.is_empty() {
+                    parts.push((cur_string, cur_status));
+                    cur_string = String::new();
+                }
+                cur_string.push(tc);
+                cur_status = status;
+            }
+            continue;
+        }
+
         let p = progress.next();
         let status = match p {
             None => Status::CurrentUntyped,
@@ -210,13 +272,30 @@ fn split_current_word(word: &TestWord) -> Vec<(String, Status)> {
     parts
 }
 
-fn split_typed_word(word: &TestWord) -> Vec<(String, Status)> {
+fn split_typed_word(word: &TestWord, qwerty: bool) -> Vec<(String, Status)> {
+    use super::test::is_typeable;
+
     let mut parts = Vec::new();
     let mut cur_string = String::new();
     let mut cur_status = Status::Untyped;
 
     let mut progress = word.progress.chars();
     for tc in word.text.chars() {
+        if qwerty && !is_typeable(tc) {
+            let status = Status::Skipped;
+            if status == cur_status {
+                cur_string.push(tc);
+            } else {
+                if !cur_string.is_empty() {
+                    parts.push((cur_string, cur_status));
+                    cur_string = String::new();
+                }
+                cur_string.push(tc);
+                cur_status = status;
+            }
+            continue;
+        }
+
         let p = progress.next();
         let status = match p {
             None => Status::Untyped,
@@ -260,6 +339,7 @@ fn word_parts_to_spans(parts: Vec<(String, Status)>, theme: &Theme) -> Vec<Span<
             Status::CurrentIncorrect => theme.prompt_current_incorrect,
             Status::Cursor => theme.prompt_current_untyped.patch(theme.prompt_cursor),
             Status::Overtyped => theme.prompt_incorrect,
+            Status::Skipped => theme.prompt_skipped,
         };
 
         spans.push(Span::styled(text, style));
@@ -467,7 +547,7 @@ mod tests {
 
             for case in cases {
                 let (word, expected) = setup(case);
-                let got = split_typed_word(&word);
+                let got = split_typed_word(&word, false);
                 assert_eq!(got, expected);
             }
         }
@@ -504,9 +584,38 @@ mod tests {
 
             for case in cases {
                 let (word, expected) = setup(case);
-                let got = split_current_word(&word);
+                let got = split_current_word(&word, false);
                 assert_eq!(got, expected);
             }
+        }
+
+        #[test]
+        fn typed_word_qwerty_skips_unicode() {
+            // Word "café" typed as "caf" — the é is shown as Skipped (yellow)
+            let mut word = TestWord::from("caf\u{00e9}");
+            word.progress = "caf".to_string();
+
+            let got = split_typed_word(&word, true);
+            let expected = vec![
+                ("caf".to_string(), Correct),
+                ("\u{00e9}".to_string(), Skipped),
+            ];
+            assert_eq!(got, expected);
+        }
+
+        #[test]
+        fn current_word_qwerty_skips_unicode() {
+            // Word "café", user has typed "ca", cursor should be on 'f'
+            let mut word = TestWord::from("caf\u{00e9}");
+            word.progress = "ca".to_string();
+
+            let got = split_current_word(&word, true);
+            let expected = vec![
+                ("ca".to_string(), CurrentCorrect),
+                ("f".to_string(), Cursor),
+                ("\u{00e9}".to_string(), Skipped),
+            ];
+            assert_eq!(got, expected);
         }
     }
 }


### PR DESCRIPTION
Did this for my own use case, thought I would make a PR in case anyone else likes these features.

--raw preserves the original file layout (line breaks, indentation, empty lines, tabs expanded to 4 spaces) so the user can practice typing structured text like source code, books, man pages.

--qwerty displays all UTF-8 but only requires the user to type ASCII-printable characters. Non-typeable characters are shown in yellow and the cursor skips over them. Entirely non-typeable words are auto-skipped.

Also added automatic scroll for longer files. 

Next thing I'm thinking about is to have the ability to paginate a file into n lines with progress saved to a file somewhere. That way, at the end of every page you get the report and the option to continue, repeat page, quit, etc. Currently I have a shell script that does all the tracking and calls the binary with just the current page.